### PR TITLE
Remove libprimac const definition

### DIFF
--- a/src/PRIMA.jl
+++ b/src/PRIMA.jl
@@ -1,7 +1,6 @@
 module PRIMA
 
 using PRIMA_jll
-const libprimac = PRIMA_jll.libprimac
 include("wrappers.jl")
 
 export bobyqa, cobyla, lincoa, newuoa, prima, uobyqa, issuccess


### PR DESCRIPTION
This definition is not needed and it breaks relocatability of PRIMA when built into a system image.