### PR TITLE
Increase maxfun for cobyla

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -251,7 +251,6 @@ end
         rhobeg = 1.0
         rhoend = 1e-5
         ftarget = -Inf
-        maxfun = 3000n
         npt = 2n + 1
         iprint = PRIMA.MSG_EXIT
 
@@ -265,6 +264,8 @@ end
         b_ineq = [6, 12, 1]
 
         @testset "$(optimizer_name(optim))" for optim in (:uobyqa, :newuoa, :bobyqa, :cobyla, :lincoa)
+            # COBYLA needs many more function evaluations than the other solvers
+            maxfun = optim == :cobyla ? 10000n : 100n
 
             println("\nUnconstrained minimization of Rosenbrock function by $(optimizer_name(optim)):")
             x0 = [-1, 2]


### PR DESCRIPTION
And make maxfun conditional on the solver since cobyla needs many more function evaluations than the other solvers.

The current failures on macos and arm  are because the COBYLA fits slightly exceed the number of allowed function evaluations (6000). I guess slight rounding differences could cause COBYLA to take some extra and costly steps.

Closes #34 